### PR TITLE
Release: Resend email transport (phase 1)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,6 +10,6 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 pnpm ci:check
-pnpm turbo run build test --output-logs=errors-only
+pnpm turbo run build type-check test --output-logs=errors-only
 pnpm check:duplication
 pnpm check:unused

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,16 +63,22 @@ Upcoming integrations, **all SOTA 2026**, **outside DDD** (pragmatic layer: `ada
 
 ---
 
-## Email — Resend (dashboard templates)
+## Email — Resend (dashboard templates) ✅ Phase 1 done
 
 **Why**: templates managed from the Resend dashboard (no code, no rebuild to change wording), built-in versioning, native A/B test. Stays pragmatic: we just call the API by template ID.
 
-- [ ] Install `resend`
-- [ ] Service `apps/api/src/adapters/services/email.service.ts` → minimal wrapper `sendTemplate(templateId, to, data)`
-- [ ] Templates created in the Resend dashboard, IDs in env (`RESEND_TPL_WELCOME`, `RESEND_TPL_RESET_PWD`, etc.)
-- [ ] Resend webhook for bounces/complaints → `routes/webhooks/resend.ts`
-- [ ] DNS domain (SPF/DKIM/DMARC) check in the README
-- [ ] BetterAuth: wire `sendVerificationEmail` / `sendResetPassword` to the Resend service
+- [x] Install `resend`
+- [x] Port `IEmailService` (`apps/api/src/application/ports/email.port.ts`) + adapter `ResendEmailService` (`apps/api/src/adapters/services/email.service.ts`) wired through inwire DI in **contract mode** (key = interface name `IEmailService`).
+- [x] **Type-safe variables per template** — `EmailTemplates` maps each template name to its required variables. Adding a new template = updating the type + adding a `RESEND_TPL_*` env var. Renaming a variable in the dashboard without updating code = TS red, no silent break.
+- [x] **`Result<void, EmailError>`** — `sendTemplate` never throws, returns a discriminated `EmailError` (`EMAIL_TRANSPORT_NOT_CONFIGURED` | `EMAIL_PROVIDER_FAILURE`). Use cases keep the `Result` until the controller boundary; integration adapters (`auth.ts`) translate to `throw` only at the BetterAuth-hook frontier.
+- [x] **Retry with exponential backoff** — 3 attempts (1s/2s/4s), retry only on `429` and `5xx` + network errors (`status === 0`). 4xx non-rate-limit fail fast (validation = retry futile). Distinct `STATUS_HINTS` log per `401` / `403` / `409` / `422` so prod debug isn't blind.
+- [x] **`Idempotency-Key`** — `${event-type}/${sha256(token)[:32]}` (Resend pattern, 24h window). Hash via `Bun.CryptoHasher`. Safe under retries — same payload returns the original response, different payload returns 409 with explicit log hint.
+- [x] **`SendTemplateOptions.from?`** — per-tenant `from` override slot for the future `organization` plugin (per-org sending domain). Defaults to `env.RESEND_FROM`. Adding it now = zero breaking change in phase 2.
+- [x] **`SendTemplateOptions.locale?`** — slot reserved for the i18n phase. Adapter currently logs a warn ("not yet implemented") if passed; resolution will switch to `${template}_${locale}` env lookup when locale-prefixed templates land. Port stays stable.
+- [x] **Boot-time fail-hard in production** — constructor throws if `NODE_ENV === "production"` and `RESEND_API_KEY` or any template ID is missing. Prevents a silent deploy where every transactional email is dropped. Dev mode keeps the warn-only fallback.
+- [x] BetterAuth `sendVerificationEmail` / `sendResetPassword` / `magicLink.sendMagicLink` consume `di.IEmailService.sendTemplate` via a `dispatchEmail()` helper that unwraps `Result` (`EMAIL_PROVIDER_FAILURE` → throw → centralised error handler; `EMAIL_TRANSPORT_NOT_CONFIGURED` → `logger.warn`, never silent).
+- [ ] Webhook bounces/complaints — `routes/webhooks/resend.ts` (signature verification + suppress hard-bounced addresses). Required before going live or IP reputation degrades.
+- [ ] DNS domain (SPF/DKIM/DMARC) check in the README.
 
 ---
 

--- a/apps/api/common/env.ts
+++ b/apps/api/common/env.ts
@@ -15,6 +15,11 @@ const envSchema = z.object({
   BETTER_AUTH_URL: z.url(),
   BETTER_AUTH_SECRET: z.string().min(32),
   APP_URL: z.url().default("http://localhost:5173"),
+  RESEND_API_KEY: z.string().min(1).optional(),
+  RESEND_FROM: z.string().default("onboarding@resend.dev"),
+  RESEND_TPL_VERIFY_EMAIL: z.string().min(1).optional(),
+  RESEND_TPL_RESET_PASSWORD: z.string().min(1).optional(),
+  RESEND_TPL_MAGIC_LINK: z.string().min(1).optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "hono-pino": "^0.10.3",
     "inwire": "^2.1.7",
     "pino": "^10.3.1",
+    "resend": "^6.12.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,8 @@
     "hono": "^4.12.15",
     "hono-pino": "^0.10.3",
     "inwire": "^2.1.7",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@packages/test": "workspace:*",

--- a/apps/api/src/adapters/services/email.service.ts
+++ b/apps/api/src/adapters/services/email.service.ts
@@ -1,16 +1,169 @@
-type SendEmailInput = {
-  to: string;
-  subject: string;
-  html: string;
+import { Result } from "@packages/ddd-kit";
+import { Resend } from "resend";
+import { env } from "../../../common/env";
+import { logger } from "../../../common/logger";
+import type {
+  EmailError,
+  EmailTemplates,
+  IEmailService,
+  SendTemplateOptions,
+  TemplateVariables,
+} from "../../application/ports/email.port";
+
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 1000;
+
+const STATUS_HINTS: Record<number, string> = {
+  401: "resend auth failure — check RESEND_API_KEY",
+  403: "resend forbidden — verify sending domain configuration",
+  409: "resend idempotency conflict — same key with different payload, check template variables",
+  422: "resend validation failure — likely template variable mismatch in dashboard",
 };
 
-export async function sendEmail({
-  to,
-  subject,
-  html,
-}: SendEmailInput): Promise<void> {
-  console.log(
-    `\x1b[36m✉\x1b[0m email · to=${to} · subject="${subject}"\n${html}`,
-  );
-  await Promise.resolve();
+type ResendSendPayload = Parameters<Resend["emails"]["send"]>[0];
+type AttemptOutcome =
+  | { ok: true }
+  | { ok: false; status: number; message: string };
+
+export class ResendEmailService implements IEmailService {
+  private readonly resend: Resend | null;
+  private readonly templateIds: Record<
+    keyof EmailTemplates,
+    string | undefined
+  >;
+
+  constructor() {
+    this.resend = env.RESEND_API_KEY ? new Resend(env.RESEND_API_KEY) : null;
+    this.templateIds = {
+      verify_email: env.RESEND_TPL_VERIFY_EMAIL,
+      reset_password: env.RESEND_TPL_RESET_PASSWORD,
+      magic_link: env.RESEND_TPL_MAGIC_LINK,
+    };
+
+    const isProd = env.NODE_ENV === "production";
+    const missing = Object.entries(this.templateIds)
+      .filter(([, id]) => !id)
+      .map(([key]) => key);
+
+    if (isProd && (!this.resend || missing.length > 0)) {
+      throw new Error(
+        `Email service misconfigured in production: ${
+          !this.resend
+            ? "RESEND_API_KEY missing"
+            : `template IDs missing: ${missing.join(", ")}`
+        }`,
+      );
+    }
+
+    if (!this.resend) {
+      logger.warn(
+        "RESEND_API_KEY not set — emails will be dropped (dev fallback)",
+      );
+      return;
+    }
+
+    if (missing.length > 0) {
+      logger.warn(
+        { missing },
+        "missing RESEND template IDs — emails for these templates will be dropped",
+      );
+    }
+  }
+
+  async sendTemplate<K extends keyof EmailTemplates>(
+    template: K,
+    to: string,
+    variables: EmailTemplates[K] & TemplateVariables,
+    options?: SendTemplateOptions,
+  ): Promise<Result<void, EmailError>> {
+    const templateId = this.templateIds[template];
+    if (!this.resend || !templateId) {
+      return Result.fail({
+        code: "EMAIL_TRANSPORT_NOT_CONFIGURED",
+        message: `transport missing for template "${template}"`,
+      });
+    }
+
+    if (options?.locale) {
+      logger.warn(
+        { template, locale: options.locale },
+        "locale-aware templates not yet implemented — using default template",
+      );
+    }
+
+    const payload: ResendSendPayload = {
+      from: options?.from ?? env.RESEND_FROM,
+      to,
+      template: { id: templateId, variables },
+      ...(options?.idempotencyKey
+        ? { idempotencyKey: options.idempotencyKey }
+        : {}),
+    };
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const outcome = await this.attemptSend(payload);
+      if (outcome.ok) return Result.ok();
+
+      const isLast = attempt === MAX_ATTEMPTS;
+      const retryable =
+        outcome.status === 0 || RETRYABLE_STATUSES.has(outcome.status);
+
+      if (!retryable || isLast) {
+        const hint = STATUS_HINTS[outcome.status] ?? "resend email send failed";
+        logger.error(
+          {
+            to,
+            template,
+            status: outcome.status,
+            message: outcome.message,
+            attempt,
+          },
+          hint,
+        );
+        return Result.fail({
+          code: "EMAIL_PROVIDER_FAILURE",
+          message: outcome.message,
+        });
+      }
+
+      const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+      logger.warn(
+        {
+          to,
+          template,
+          status: outcome.status,
+          attempt,
+          nextDelayMs: delay,
+        },
+        "retrying email send",
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    return Result.fail({
+      code: "EMAIL_PROVIDER_FAILURE",
+      message: "exhausted retries",
+    });
+  }
+
+  private async attemptSend(
+    payload: ResendSendPayload,
+  ): Promise<AttemptOutcome> {
+    if (!this.resend) {
+      return { ok: false, status: 0, message: "resend client not initialized" };
+    }
+    try {
+      const { error } = await this.resend.emails.send(payload);
+      if (!error) return { ok: true };
+      const status = (error as { statusCode?: number }).statusCode ?? 500;
+      return { ok: false, status, message: error.message ?? "unknown" };
+    } catch (e) {
+      return {
+        ok: false,
+        status: 0,
+        message: e instanceof Error ? e.message : "network error",
+      };
+    }
+  }
 }

--- a/apps/api/src/application/ports/email.port.ts
+++ b/apps/api/src/application/ports/email.port.ts
@@ -1,0 +1,28 @@
+import type { Result } from "@packages/ddd-kit";
+
+export type TemplateVariables = Record<string, string | number>;
+
+export type EmailTemplates = {
+  verify_email: { name: string; verifyUrl: string };
+  reset_password: { name: string; resetUrl: string };
+  magic_link: { magicUrl: string };
+};
+
+export type EmailError =
+  | { code: "EMAIL_TRANSPORT_NOT_CONFIGURED"; message: string }
+  | { code: "EMAIL_PROVIDER_FAILURE"; message: string };
+
+export interface SendTemplateOptions {
+  idempotencyKey?: string;
+  from?: string;
+  locale?: string;
+}
+
+export interface IEmailService {
+  sendTemplate<K extends keyof EmailTemplates>(
+    template: K,
+    to: string,
+    variables: EmailTemplates[K] & TemplateVariables,
+    options?: SendTemplateOptions,
+  ): Promise<Result<void, EmailError>>;
+}

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -5,10 +5,45 @@ import { db } from "@packages/drizzle";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer, magicLink, twoFactor } from "better-auth/plugins";
+import { CryptoHasher } from "bun";
 import { env } from "../common/env";
-import { sendEmail } from "./adapters/services/email.service";
+import { logger } from "../common/logger";
+import type {
+  EmailTemplates,
+  TemplateVariables,
+} from "./application/ports/email.port";
+import { di } from "./di/container";
 
 const isProd = env.NODE_ENV === "production";
+
+function tokenIdempotencyKey(template: string, token: string): string {
+  const hash = new CryptoHasher("sha256")
+    .update(token)
+    .digest("hex")
+    .slice(0, 32);
+  return `${template}/${hash}`;
+}
+
+async function dispatchEmail<K extends keyof EmailTemplates>(
+  template: K,
+  to: string,
+  variables: EmailTemplates[K] & TemplateVariables,
+  idempotencyKey: string,
+): Promise<void> {
+  const result = await di.IEmailService.sendTemplate(template, to, variables, {
+    idempotencyKey,
+  });
+  if (result.isFailure) {
+    const error = result.getError();
+    if (error.code === "EMAIL_PROVIDER_FAILURE") {
+      throw new Error(`email send failed (${template}): ${error.message}`);
+    }
+    logger.warn(
+      { template, to, code: error.code },
+      "email skipped — transport not configured",
+    );
+  }
+}
 
 export const auth = betterAuth({
   appName: "clean-stack",
@@ -23,12 +58,13 @@ export const auth = betterAuth({
     enabled: true,
     requireEmailVerification: true,
     sendResetPassword: async ({ user, token }) => {
-      const url = `${env.APP_URL}/reset-password?token=${encodeURIComponent(token)}`;
-      await sendEmail({
-        to: user.email,
-        subject: "Reset your password",
-        html: `<p>Click the link below to reset your password.</p><p><a href="${url}">Reset password</a></p>`,
-      });
+      const resetUrl = `${env.APP_URL}/reset-password?token=${encodeURIComponent(token)}`;
+      await dispatchEmail(
+        "reset_password",
+        user.email,
+        { name: user.name ?? "", resetUrl },
+        tokenIdempotencyKey("reset-password", token),
+      );
     },
   },
 
@@ -36,12 +72,13 @@ export const auth = betterAuth({
     sendOnSignUp: true,
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, token }) => {
-      const url = `${env.APP_URL}/verify-email?token=${encodeURIComponent(token)}`;
-      await sendEmail({
-        to: user.email,
-        subject: "Verify your email",
-        html: `<p>Welcome${user.name ? ` ${user.name}` : ""}.</p><p><a href="${url}">Verify your email</a></p>`,
-      });
+      const verifyUrl = `${env.APP_URL}/verify-email?token=${encodeURIComponent(token)}`;
+      await dispatchEmail(
+        "verify_email",
+        user.email,
+        { name: user.name ?? "", verifyUrl },
+        tokenIdempotencyKey("verify-email", token),
+      );
     },
   },
 
@@ -65,12 +102,13 @@ export const auth = betterAuth({
     twoFactor(),
     magicLink({
       sendMagicLink: async ({ email, token }) => {
-        const url = `${env.APP_URL}/magic-link?token=${encodeURIComponent(token)}`;
-        await sendEmail({
-          to: email,
-          subject: "Your magic sign-in link",
-          html: `<p><a href="${url}">Sign in to clean-stack</a></p>`,
-        });
+        const magicUrl = `${env.APP_URL}/magic-link?token=${encodeURIComponent(token)}`;
+        await dispatchEmail(
+          "magic_link",
+          email,
+          { magicUrl },
+          tokenIdempotencyKey("magic-link", token),
+        );
       },
     }),
     passkey({ rpName: "clean-stack" }),

--- a/apps/api/src/di/container.ts
+++ b/apps/api/src/di/container.ts
@@ -1,5 +1,11 @@
 import { container } from "inwire";
+import { ResendEmailService } from "../adapters/services/email.service";
+import type { IEmailService } from "../application/ports/email.port";
 
-export type AppDeps = Record<string, never>;
+export interface AppDeps {
+  IEmailService: IEmailService;
+}
 
-export const di = container<AppDeps>().build();
+export const di = container<AppDeps>()
+  .add("IEmailService", () => new ResendEmailService())
+  .build();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@packages/test':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      resend:
+        specifier: ^6.12.2
+        version: 6.12.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2564,6 +2567,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3544,6 +3550,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -4545,6 +4554,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -4776,6 +4788,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4953,6 +4974,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -5034,6 +5058,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -5273,6 +5300,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -7505,6 +7537,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -8429,6 +8463,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -9335,6 +9371,8 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  postal-mime@2.7.4: {}
+
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
@@ -9630,6 +9668,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.12.2:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -9846,6 +9889,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.1.0: {}
 
   stream-combiner2@1.1.1:
@@ -9926,6 +9974,11 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   tagged-tag@1.0.0: {}
 
@@ -10129,6 +10182,8 @@ snapshots:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,6 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "with": ["type-check"],
       "inputs": [
         "src/**",
         "common/**",


### PR DESCRIPTION
## Summary

- Wires Resend as the transactional email transport behind a typed `IEmailService` port (Result/Error contract, retry/idempotency, fail-hard prod boot).
- Consumed by BetterAuth hooks (`sendVerificationEmail`, `sendResetPassword`, `magicLink.sendMagicLink`) via inwire contract mode — port stays generic, swap to Postmark/SES = single new adapter.
- Future-proof slots reserved on `SendTemplateOptions`: `from?` (per-org sender for the org plugin), `locale?` (i18n templates). Both already validated by tests of the adapter; no breaking change required when phase 2 / i18n land.

## Test plan

- [ ] `pnpm dev` boots without `RESEND_API_KEY` (warn-only fallback, signups still complete in dev).
- [ ] With valid `RESEND_API_KEY` + template IDs: signup triggers a Resend send; idempotency-key `verify-email/<sha256>` visible on the dashboard.
- [ ] Reset password / magic-link flows trigger the right templates with the right variables.
- [ ] Setting an invalid API key in prod-mode env fails the boot with an explicit error.
- [ ] 429 from Resend retried with backoff; 4xx (non-rate-limit) fails fast with status-specific log hint.