### PR TITLE
fix(app): bind vite preview for railway demo

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port ${PORT:-4173}",
     "type-check": "tsc --noEmit",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
Default `vite preview` binds `127.0.0.1:4173` so Railway edge returns 502. Explicit `--host 0.0.0.0 --port \${PORT:-4173}` unblocks the demo container.

## Test plan
- [ ] Railway app service deploys, `https://app-production-*.up.railway.app/` returns 200