### PR TITLE
fix(api): run migrations on boot + ui tailwindcss dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd my-saas
 pnpm install
 pnpm bootstrap          # copies .env.example → .env in each workspace
 docker compose up -d    # Postgres on :5433
-pnpm db:push            # apply schema
+pnpm db:migrate         # apply migrations
 pnpm dev                # API :3000, App :5173
 ```
 
@@ -59,9 +59,7 @@ No Bun, no Node, no pnpm on your host. Everything runs in containers (api + app 
 git clone https://github.com/axelhamil/clean-stack my-saas
 cd my-saas
 bash scripts/bootstrap.sh              # copies .env.example → .env in each workspace
-docker compose up --watch
-# once Postgres is healthy, in another terminal:
-docker compose exec api pnpm db:push
+docker compose up --watch              # api runs migrations on boot, then starts
 ```
 
 Open [`http://localhost:5173`](http://localhost:5173), sign up with any email, you're in.

--- a/apps/api/dev.Dockerfile
+++ b/apps/api/dev.Dockerfile
@@ -17,4 +17,6 @@ RUN pnpm --filter "@packages/*" run build
 
 EXPOSE 3000
 
-CMD ["pnpm", "turbo", "dev", "--filter=api"]
+ENV MIGRATIONS_FOLDER=packages/drizzle/migrations
+
+CMD ["sh", "-c", "bun apps/api/src/migrate.ts && pnpm turbo dev --filter=api"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "dev": "bun --hot src/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target bun --minify",
-    "start": "bun dist/index.js",
+    "build": "bun build src/index.ts src/migrate.ts --outdir dist --target bun --minify",
+    "migrate": "bun src/migrate.ts",
+    "start": "bun dist/migrate.js && bun dist/index.js",
     "type-check": "tsc --noEmit",
     "test": "bun test --pass-with-no-tests",
     "test:watch": "bun test --watch --pass-with-no-tests",

--- a/apps/api/prod.Dockerfile
+++ b/apps/api/prod.Dockerfile
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY --from=pruner /repo/out/full/ ./
 
 RUN pnpm --filter "@packages/*" run build
-RUN cd apps/api && bun build src/index.ts --outdir dist --target bun --minify
+RUN cd apps/api && bun build src/index.ts src/migrate.ts --outdir dist --target bun --minify
 
 FROM oven/bun:1.3.6-alpine AS runner
 WORKDIR /app
@@ -22,6 +22,9 @@ WORKDIR /app
 RUN apk add --no-cache wget
 
 COPY --from=builder --chown=bun:bun /repo/apps/api/dist /app/dist
+COPY --from=builder --chown=bun:bun /repo/packages/drizzle/migrations /app/migrations
+
+ENV MIGRATIONS_FOLDER=/app/migrations
 
 USER bun
 EXPOSE 3000
@@ -29,7 +32,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- "http://localhost:${PORT:-3000}/health" || exit 1
 
-# Migrations: not run inside the runtime container.
-# On Railway, set the service "Pre-Deploy Command" to: pnpm db:migrate
-# (drizzle-kit + migrations live in @packages/drizzle, kept out of the runner for image size).
-CMD ["bun", "dist/index.js"]
+CMD ["sh", "-c", "bun dist/migrate.js && bun dist/index.js"]

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -1,0 +1,9 @@
+import { db, migrate } from "@packages/drizzle";
+import { logger } from "./shared/logger";
+
+const migrationsFolder = process.env.MIGRATIONS_FOLDER ?? "./migrations";
+
+logger.info({ migrationsFolder }, "running migrations");
+await migrate(db, { migrationsFolder });
+logger.info("migrations applied");
+process.exit(0);

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -161,7 +161,7 @@ If your event is in `RETENTION_MAP` with `operational` or `compliance`:
 
 ## Setup checklist post-clone
 
-1. `pnpm db:push` (creates `outbox_event`, `audit_log`, `webhook_endpoint`, `webhook_delivery`)
+1. Tables (`outbox_event`, `audit_log`, `webhook_endpoint`, `webhook_delivery`) are created automatically — the api runs `drizzle migrate` at boot before `OutboxDispatcher.start()` (`apps/api/src/migrate.ts`). In native dev, `pnpm db:migrate` once before `pnpm dev` if you skipped Docker.
 2. Set env vars in `apps/api/.env`:
    - `WEBHOOK_MASTER_KEY=<64 hex chars>` — generate via `openssl rand -hex 32` (required in production)
    - `AUDIT_TAMPER_EVIDENCE=false` — leave off; flip to `true` only when SOC2 audit demands hash chain

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -16,6 +16,7 @@ export {
   or,
   sql,
 } from "drizzle-orm";
+export { migrate } from "drizzle-orm/node-postgres/migrator";
 export type { AnyPgTable } from "drizzle-orm/pg-core";
 export { type DbClient, db, type Transaction } from "./config";
 export { trackEventsOnSuccess } from "./repositories/track-events";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,6 +47,7 @@
     "radix-ui": "^1.4.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0


### PR DESCRIPTION
## Summary
- **Closes #29** — cold-started containers crashed at `OutboxDispatcher.ensureNotifyTrigger()` with `relation "outbox_event" does not exist` because the api booted against an empty DB. Now `drizzle migrate` runs at boot before `OutboxDispatcher.start()`.
- Pre-existing latent bug exposed: `packages/ui` didn't declare `tailwindcss` as a dep — `vite build` fails on cold install (turbo cache was masking it).

## Changes
- `apps/api/src/migrate.ts` standalone runner via `drizzle-orm/node-postgres/migrator`
- Re-export `migrate` from `@packages/drizzle` (façade)
- `dev.Dockerfile` + `prod.Dockerfile` chain migrate before serve; prod runner is now self-contained (no more Pre-Deploy Command requirement)
- `packages/ui` declares `tailwindcss: ^4.2.4` (matches apps/app)
- README + docs/EVENTS.md updated (drop manual `db:push` step from Option B)

## Test plan
- [x] Cold-started `docker compose up --watch` from a wiped Docker (0 image, 0 cache) — api healthy in 15s
- [x] 13 tables created, 3 migrations recorded in `__drizzle_migrations`, trigger `outbox_notify_trigger` active
- [x] End-to-end Chrome flow: sign-up → verify-email → /dashboard → sign-out → sign-in → 4 outbox events dispatched + 4 audit rows
- [x] `pnpm --filter app build` green
