### PR TITLE
docs(readme): WIP status notice + low-effort issue policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Auth, multi-tenant, email, storage already wired. You clone, you write business 
 
 ---
 
+> **Status — work in progress.** This boilerplate is under active iteration. No support guarantee, no SLA on issues. "Doesn't work on my machine" reports without (a) a fresh-clone repro following [Quick start](#quick-start) to the letter, and (b) the output of `pnpm -v && bun -v && docker compose version`, will be closed without comment. Drive-by lectures on tooling choices ("`docker compose` doesn't exist on Linux", "your stack is broken because my distro is from 2019", …) are not feedback — they're noise, and they get the same treatment.
+
+---
+
 ## Quick start
 
 Two ways to run it. Pick one.


### PR DESCRIPTION
## Summary

Adds a WIP status notice at the top of the README setting expectations for incoming issues. The project is under active iteration, no support guarantee, no SLA. Low-effort "doesn't work on my machine" reports without a fresh-clone repro and a tooling-version dump (`pnpm -v && bun -v && docker compose version`) will be closed without comment.

The notice is also explicit about the kind of drive-by lectures that have shown up in recent issues ("`docker compose` doesn't exist on Linux", distro-age complaints) and confirms they will be treated as noise.

## Test plan

- [x] Renders correctly on GitHub (markdown blockquote)
- [x] Placed below the centered header block + first `---` so badges and tagline stay above the fold
- [x] Anchors to `#quick-start` resolve

Triggers a `patch` release per `.releaserc.json` (docs(readme) → patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jn1ehx1RWeHtbe6PU8AVpN)_