### PR TITLE
docs(readme): rephrase WIP notice in neutral terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Auth, multi-tenant, email, storage already wired. You clone, you write business 
 
 ---
 
-> **Status — work in progress.** This boilerplate is under active iteration. No support guarantee, no SLA on issues. "Doesn't work on my machine" reports without (a) a fresh-clone repro following [Quick start](#quick-start) to the letter, and (b) the output of `pnpm -v && bun -v && docker compose version`, will be closed without comment. Drive-by lectures on tooling choices ("`docker compose` doesn't exist on Linux", "your stack is broken because my distro is from 2019", …) are not feedback — they're noise, and they get the same treatment.
+> **Status — work in progress.** This boilerplate is under active iteration. No support guarantee, no SLA on issues. Setup issues are accepted only with (a) a fresh-clone repro following [Quick start](#quick-start) step-by-step, and (b) the output of `pnpm -v && bun -v && docker compose version`. Reports missing either will be closed without comment. Bug reports — with a minimal repro, expected vs. actual behavior, and the same tooling-version dump — are very welcome.
 
 ---
 


### PR DESCRIPTION
## Summary

The WIP notice added in #34 included editorialized examples that read as targeted call-outs. This PR drops the examples while keeping the substantive policy intact:

- Setup issues require (a) a fresh-clone repro following Quick start, and (b) the output of `pnpm -v && bun -v && docker compose version`.
- Reports missing either are closed without comment.
- Bug reports are explicitly welcomed when filed with a minimal repro, expected vs. actual behavior, and the same tooling-version dump.

The tone now describes the bar, not the noise.

## Test plan

- [x] Markdown still renders as a single blockquote
- [x] Anchor `#quick-start` still resolves
- [x] No targeted phrasing remains

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jn1ehx1RWeHtbe6PU8AVpN)_