### PR TITLE
fix(events): tx-aware emitEvent + atomic rgpd writes

### DIFF
--- a/apps/api/src/modules/rgpd/__TESTS__/rgpd.service.test.ts
+++ b/apps/api/src/modules/rgpd/__TESTS__/rgpd.service.test.ts
@@ -255,7 +255,7 @@ describe("RgpdService", () => {
       const result = await service.cancelAccountDeletion({ userId: "u1" });
 
       expect(result.isSuccess).toBe(true);
-      expect(repo.clearPendingDeletion).toHaveBeenCalledWith("u1");
+      expect(repo.clearPendingDeletion).toHaveBeenCalledWith("u1", expect.anything());
       expect(email.sendTemplate).toHaveBeenCalledWith(
         "delete_cancelled",
         "u@example.com",
@@ -567,7 +567,7 @@ describe("RgpdService", () => {
         expect.objectContaining({ name: "User", downloadUrl: expect.any(String) }),
         expect.objectContaining({ idempotencyKey: expect.any(String) }),
       );
-      expect(repo.touchExportRequestedAt).toHaveBeenCalledWith("u1");
+      expect(repo.touchExportRequestedAt).toHaveBeenCalledWith("u1", expect.anything());
     });
 
     it("succeeds even when email send fails", async () => {

--- a/apps/api/src/modules/rgpd/application/services/rgpd.service.ts
+++ b/apps/api/src/modules/rgpd/application/services/rgpd.service.ts
@@ -132,13 +132,21 @@ export class RgpdService {
     }
 
     const until = new Date(Date.now() + (env.RGPD_GRACE_PERIOD_DAYS ?? 7) * 24 * 60 * 60 * 1000);
-    const marked = await this.rgpd.markPendingDeletion(input.userId, until);
-    if (marked.isFailure) return Result.fail(marked.getError());
-
-    await emitEvent(this.outbox, EventTypes.USER_DELETION_REQUESTED, "user", input.userId, {
-      userId: input.userId,
-      pendingDeletionUntil: until,
+    const txResult = await this.transactions.run(async (tx) => {
+      const marked = await this.rgpd.markPendingDeletion(input.userId, until, tx);
+      if (marked.isFailure) return marked;
+      await emitEvent(
+        this.outbox,
+        EventTypes.USER_DELETION_REQUESTED,
+        "user",
+        input.userId,
+        { userId: input.userId, pendingDeletionUntil: until },
+        {},
+        tx,
+      );
+      return Result.ok<void, RgpdError>(undefined);
     });
+    if (txResult.isFailure) return Result.fail(txResult.getError());
 
     const cancelUrl = `${env.APP_URL}/settings/account`;
     const sent = await this.email.sendTemplate(
@@ -179,12 +187,21 @@ export class RgpdService {
       });
     const pendingUntil = state.pendingDeletionUntil.unwrap();
 
-    const cleared = await this.rgpd.clearPendingDeletion(input.userId);
-    if (cleared.isFailure) return Result.fail(cleared.getError());
-
-    await emitEvent(this.outbox, EventTypes.USER_DELETION_CANCELLED, "user", input.userId, {
-      userId: input.userId,
+    const txResult = await this.transactions.run(async (tx) => {
+      const cleared = await this.rgpd.clearPendingDeletion(input.userId, tx);
+      if (cleared.isFailure) return cleared;
+      await emitEvent(
+        this.outbox,
+        EventTypes.USER_DELETION_CANCELLED,
+        "user",
+        input.userId,
+        { userId: input.userId },
+        {},
+        tx,
+      );
+      return Result.ok<void, RgpdError>(undefined);
     });
+    if (txResult.isFailure) return Result.fail(txResult.getError());
 
     const sent = await this.email.sendTemplate(
       "delete_cancelled",
@@ -228,9 +245,20 @@ export class RgpdService {
 
     let wipeOutput: ExecuteWipeOutput;
     try {
-      const inner = await this.transactions.startTransaction(async (trx) =>
-        this.rgpd.executeWipe(input.userId, trx),
-      );
+      const inner = await this.transactions.run(async (trx) => {
+        const wipe = await this.rgpd.executeWipe(input.userId, trx);
+        if (wipe.isFailure) return wipe;
+        await emitEvent(
+          this.outbox,
+          EventTypes.USER_DELETED,
+          "user",
+          input.userId,
+          { userId: input.userId, deletedAt: new Date() },
+          {},
+          trx,
+        );
+        return wipe;
+      });
       if (inner.isFailure) {
         logger.error(
           { userId: input.userId, code: inner.getError().code },
@@ -249,11 +277,6 @@ export class RgpdService {
         message: "wipe transaction failed",
       });
     }
-
-    await emitEvent(this.outbox, EventTypes.USER_DELETED, "user", input.userId, {
-      userId: input.userId,
-      deletedAt: new Date(),
-    });
 
     // Storage cleanup is post-tx: object storage isn't transactional, so we accept
     // the tradeoff. A crash here leaves orphaned blobs but the DB row is already
@@ -395,14 +418,25 @@ export class RgpdService {
     });
     if (presigned.isFailure) return Result.fail(presigned.getError());
 
-    const touched = await this.rgpd.touchExportRequestedAt(input.userId);
-    if (touched.isFailure) return Result.fail(touched.getError());
-
-    await emitEvent(this.outbox, EventTypes.USER_EXPORT_COMPLETED, "user", input.userId, {
-      userId: input.userId,
-      storageKey: key,
-      expiresAt: new Date(presigned.getValue().expiresAt),
+    const txResult = await this.transactions.run(async (tx) => {
+      const touched = await this.rgpd.touchExportRequestedAt(input.userId, tx);
+      if (touched.isFailure) return touched;
+      await emitEvent(
+        this.outbox,
+        EventTypes.USER_EXPORT_COMPLETED,
+        "user",
+        input.userId,
+        {
+          userId: input.userId,
+          storageKey: key,
+          expiresAt: new Date(presigned.getValue().expiresAt),
+        },
+        {},
+        tx,
+      );
+      return Result.ok<void, RgpdError>(undefined);
     });
+    if (txResult.isFailure) return Result.fail(txResult.getError());
 
     const sent = await this.email.sendTemplate(
       "data_export_ready",

--- a/apps/api/src/shared/event-emitter.ts
+++ b/apps/api/src/shared/event-emitter.ts
@@ -1,6 +1,6 @@
 import type { IDomainEvent } from "@packages/ddd-kit";
+import type { Transaction } from "@packages/drizzle";
 import type { EventType } from "@packages/events";
-import { logger } from "./logger";
 import type { IOutboxRepository } from "./ports/outbox.port";
 
 const SOURCE = "app/api";
@@ -17,6 +17,7 @@ export async function emitEvent<TPayload>(
   aggregateId: string,
   payload: TPayload,
   opts: EmitOptions = {},
+  tx?: Transaction,
 ): Promise<void> {
   const event: IDomainEvent<TPayload> = {
     eventType,
@@ -24,14 +25,14 @@ export async function emitEvent<TPayload>(
     aggregateId,
     payload,
   };
-  try {
-    await outbox.enqueue([event], {
+  await outbox.enqueue(
+    [event],
+    {
       source: SOURCE,
       aggregateType,
       organizationId: opts.organizationId,
       traceparent: opts.traceparent,
-    });
-  } catch (err) {
-    logger.error({ err, eventType, aggregateId }, "outbox enqueue failed");
-  }
+    },
+    tx,
+  );
 }


### PR DESCRIPTION
## Summary
- `emitEvent` now accepts an optional `tx?: Transaction` so an outbox INSERT can join an in-progress UoW transaction
- Drop the `catch` that silently swallowed outbox failures — failed enqueues now propagate to the caller (compliance > best-effort)
- `rgpd.service` writes that ship state-change events are now wrapped in `uow.run` and pass the TX through:
  - `requestAccountDeletion` (markPendingDeletion + USER_DELETION_REQUESTED)
  - `cancelAccountDeletion` (clearPendingDeletion + USER_DELETION_CANCELLED)
  - `executeAccountWipe` (migrated `startTransaction` → `run`; USER_DELETED emitted inside the TX)
  - `requestDataExport` (touchExportRequestedAt + USER_EXPORT_COMPLETED)

`upload.service` and `auth.ts` keep autonomous-TX emits — no local DB write to attach to, and BetterAuth hooks don't expose a `Transaction`.

## Test plan
- [x] `bun test src/modules/rgpd` — 31 pass
- [x] `tsc --noEmit` — clean
- [x] Husky pre-push (turbo build/type-check/test + jscpd) — green