### PR TITLE
fix(deploy): run api from ts source instead of bundling

### DIFF
--- a/apps/api/prod.Dockerfile
+++ b/apps/api/prod.Dockerfile
@@ -3,32 +3,23 @@ WORKDIR /repo
 COPY . .
 RUN npx -y turbo@2.9.6 prune api --docker
 
-FROM node:24.15.0-alpine AS builder
-COPY --from=oven/bun:1.3.6-alpine /usr/local/bin/bun /usr/local/bin/bun
-RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
+FROM oven/bun:1.3.6-alpine AS runner
+RUN apk add --no-cache wget nodejs npm
+RUN npm install -g pnpm@10.33.2
+
 WORKDIR /repo
 
 COPY --from=pruner /repo/out/json/ ./
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod
 
 COPY --from=pruner /repo/out/full/ ./
 
-RUN cd apps/api && bun build src/index.ts src/migrate.ts src/cron/sweep.ts --outdir dist --target bun --minify
+ENV MIGRATIONS_FOLDER=/repo/packages/drizzle/migrations
+ENV NODE_ENV=production
 
-FROM oven/bun:1.3.6-alpine AS runner
-WORKDIR /app
-
-RUN apk add --no-cache wget
-
-COPY --from=builder --chown=bun:bun /repo/apps/api/dist /app/dist
-COPY --from=builder --chown=bun:bun /repo/packages/drizzle/migrations /app/migrations
-
-ENV MIGRATIONS_FOLDER=/app/migrations
-
-USER bun
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- "http://localhost:${PORT:-3000}/livez" || exit 1
 
-CMD ["sh", "-c", "bun dist/migrate.js && bun dist/index.js"]
+CMD ["sh", "-c", "bun apps/api/src/migrate.ts && bun apps/api/src/index.ts"]

--- a/infra/railway/cron.toml
+++ b/infra/railway/cron.toml
@@ -13,6 +13,6 @@ watchPatterns = [
 
 [deploy]
 cronSchedule = "17 3 * * *"
-startCommand = "bun dist/cron/sweep.js"
+startCommand = "bun apps/api/src/cron/sweep.ts"
 restartPolicyType = "NEVER"
 


### PR DESCRIPTION
## Summary

Fixe le crash runtime du service api sur Railway après merge de Phase 0.7. `bun build --minify` bake un path absolu pnpm `/repo/node_modules/.pnpm/thread-stream@4.2.0/.../worker.js` dans le bundle, le runner stage ne l'a pas → `ModuleNotFound` au premier log via pino transport worker.

Switch au pattern Bun idiomatique : no-bundle, install prod deps dans le runner, run TS directement (`bun src/index.ts`). Bun parse TS aussi vite que JS minifié. Élimine la classe entière de hidden-deps-in-bundle bugs (pino, sharp, n'importe quelle lib qui spawn worker / dlopen).

## Test plan

- [x] `docker build -f apps/api/prod.Dockerfile -t test .` → OK
- [x] `docker run --rm -e NODE_ENV=production ... test bun apps/api/src/migrate.ts` → boot OK, logger émet JSON propre, atteint Drizzle (échoue sur DB absente, attendu)
- [ ] Redeploy Railway api → `/livez` 200
- [ ] Redeploy Railway cron → `bun apps/api/src/cron/sweep.ts` boot OK