### PR TITLE
fix(auth): silence cancelled passkey conditional-ui toast on sign-in

### DIFF
--- a/apps/app/src/features/auth/hooks/use-passkey-autofill.ts
+++ b/apps/app/src/features/auth/hooks/use-passkey-autofill.ts
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import { sessionQueryOptions } from "../../../shared/api/queries/session";
 import { broadcastAuthChange } from "../../../shared/auth/auth-broadcast";
 import { authClient } from "../../../shared/auth/auth-client";
-import { toastError } from "../../../shared/utils";
 
 interface UsePasskeyAutofillOptions {
   enabled: boolean;
@@ -36,21 +35,13 @@ export function usePasskeyAutofill({
           autoFill: true,
           fetchOptions: { signal: controller.signal },
         });
-        if (controller.signal.aborted) return;
-        if (result?.error) {
-          const message = result.error.message?.toLowerCase() ?? "";
-          if (message.includes("not allowed")) return;
-          toastError(result.error, "Passkey sign-in failed");
-          return;
-        }
+        if (controller.signal.aborted || result?.error) return;
         toast.success("Welcome back");
         await queryClient.refetchQueries({ queryKey: sessionQueryOptions.queryKey });
         broadcastAuthChange();
         void navigate({ to: redirectTo ?? "/" });
-      } catch (err) {
-        if (controller.signal.aborted) return;
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        toastError(err, "Passkey sign-in failed");
+      } catch {
+        // passive conditional passkey UI — cancel / abort / no-credential are expected, never surfaced
       }
     })();
 

--- a/apps/app/src/features/auth/hooks/use-sign-in-passkey.ts
+++ b/apps/app/src/features/auth/hooks/use-sign-in-passkey.ts
@@ -22,8 +22,8 @@ export function useSignInPasskey(redirectTo?: string) {
         fetchOptions: { signal: controller.signal },
       });
       if (result?.error) {
-        if (result.error.message?.toLowerCase().includes("not allowed"))
-          throw new Error("Cancelled");
+        const msg = result.error.message?.toLowerCase() ?? "";
+        if (msg.includes("not allowed") || msg.includes("cancel")) throw new Error("Cancelled");
         throw new Error(result.error.message ?? "Passkey sign-in failed");
       }
     },


### PR DESCRIPTION
Patch — hotfix for the prod sign-in page.

The passkey conditional UI (autofill) mounts on `/sign-in` load; on a fresh domain with no registered passkey the WebAuthn ceremony self-cancels and BetterAuth returns `error.message = "Auth cancelled"`, which the guard (only matching "not allowed") let through to a toast — every visitor saw an error toast on page load.

Conditional UI is now silent on any failure (cancel/abort/no-credential are all expected); only success surfaces. The explicit "Sign in with passkey" button still surfaces real errors, with broadened cancel detection.

ci:check green.